### PR TITLE
Add dependabot configuration targeting develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Adds dependabot.yml for weekly Maven dependency scanning targeting the develop branch. Task: TASK-079.