### PR TITLE
fix: implement removeValidators() no-op — TASK-304

### DIFF
--- a/src/main/java/io/kestros/commons/validation/core/services/impl/ModelValidatorRegistrationHandlerServiceImpl.java
+++ b/src/main/java/io/kestros/commons/validation/core/services/impl/ModelValidatorRegistrationHandlerServiceImpl.java
@@ -177,13 +177,24 @@ public class ModelValidatorRegistrationHandlerServiceImpl
 
   @Override
   public void removeValidators(@Nonnull List<ModelValidator> modelValidators, @Nonnull Class type) {
-    // todo may not be needed.
-    //    if (registeredModelValidatorMap.containsKey(type)) {
-    //      List<RegisteredModelValidator> newRegisteredModelValidatorList = new ArrayList<>();
-    //
-    //      registeredModelValidatorMap.remove(type);
-    //      registeredModelValidatorMap.put(type, newRegisteredModelValidatorList);
-    //    }
+    if (!registeredModelValidatorMap.containsKey(type)) {
+      return;
+    }
+    List<ModelValidator> registeredValidators = registeredModelValidatorMap.get(type);
+    for (ModelValidator validatorToRemove : modelValidators) {
+      if (validatorToRemove == null || validatorToRemove.getMessage() == null) {
+        continue;
+      }
+      registeredValidators.removeIf(existing ->
+              existing.getMessage() != null
+                      && existing.getMessage().equals(validatorToRemove.getMessage()));
+      if (modelValidationActivateStatusService != null) {
+        modelValidationActivateStatusService.deactivateValidator(validatorToRemove, type);
+      }
+    }
+    if (registeredValidators.isEmpty()) {
+      registeredModelValidatorMap.remove(type);
+    }
   }
 
   /**

--- a/src/test/java/io/kestros/commons/validation/core/services/impl/ModelValidatorRegistrationHandlerServiceImplTest.java
+++ b/src/test/java/io/kestros/commons/validation/core/services/impl/ModelValidatorRegistrationHandlerServiceImplTest.java
@@ -21,6 +21,7 @@ package io.kestros.commons.validation.core.services.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -194,9 +195,9 @@ public class ModelValidatorRegistrationHandlerServiceImplTest {
                                       .size());
     registrationHandlerService.removeValidators(registrationService1.getModelValidators(),
             BaseResource.class);
-    assertEquals(0,
-            registrationHandlerService.getRegisteredModelValidatorMap().get(BaseResource.class)
-                                      .size());
+    // All validators removed for BaseResource, so the key is cleaned up
+    assertNull(
+            registrationHandlerService.getRegisteredModelValidatorMap().get(BaseResource.class));
   }
 
   @Test
@@ -241,9 +242,9 @@ public class ModelValidatorRegistrationHandlerServiceImplTest {
             new ArrayList<>(validators));
     // Should not throw NullPointerException when activateStatusService is null
     handlerWithoutActivateService.removeValidators(validators, BaseResource.class);
-    assertEquals(0,
-            handlerWithoutActivateService.registeredModelValidatorMap.get(BaseResource.class)
-                                         .size());
+    // All validators removed, key cleaned up
+    assertNull(
+            handlerWithoutActivateService.registeredModelValidatorMap.get(BaseResource.class));
   }
 
   @Test

--- a/src/test/java/io/kestros/commons/validation/core/services/impl/ModelValidatorRegistrationHandlerServiceImplTest.java
+++ b/src/test/java/io/kestros/commons/validation/core/services/impl/ModelValidatorRegistrationHandlerServiceImplTest.java
@@ -39,7 +39,6 @@ import org.apache.felix.hc.api.FormattingResultLog;
 import org.apache.felix.hc.api.Result;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -176,17 +175,75 @@ public class ModelValidatorRegistrationHandlerServiceImplTest {
 
 
   @Test
-  @Ignore
   public void testUnregisterValidators() {
-    assertEquals(0, registrationHandlerService.getRegisteredModelValidatorMap().size());
+    context.registerService(ModelValidatorRegistrationService.class, registrationService1);
+    context.registerService(ModelValidatorRegistrationService.class, registrationService2);
     context.registerInjectActivateService(registrationHandlerService);
     assertEquals(2, registrationHandlerService.getRegisteredModelValidatorMap().size());
     registrationHandlerService.unregisterAllValidatorsFromService(registrationService1);
-    assertEquals(0, registrationHandlerService.getRegisteredModelValidatorMap().size());
+    assertEquals(1, registrationHandlerService.getRegisteredModelValidatorMap().size());
   }
 
   @Test
-  public void testRemoveValidators() {
+  public void testRemoveValidatorsRemovesMatchingValidators() {
+    context.registerService(ModelValidatorRegistrationService.class, registrationService1);
+    context.registerService(ModelValidatorRegistrationService.class, registrationService2);
+    context.registerInjectActivateService(registrationHandlerService);
+    assertEquals(2,
+            registrationHandlerService.getRegisteredModelValidatorMap().get(BaseResource.class)
+                                      .size());
+    registrationHandlerService.removeValidators(registrationService1.getModelValidators(),
+            BaseResource.class);
+    assertEquals(0,
+            registrationHandlerService.getRegisteredModelValidatorMap().get(BaseResource.class)
+                                      .size());
+  }
+
+  @Test
+  public void testRemoveValidatorsDeactivatesValidators() {
+    context.registerService(ModelValidatorRegistrationService.class, registrationService1);
+    context.registerService(ModelValidatorRegistrationService.class, registrationService2);
+    context.registerInjectActivateService(registrationHandlerService);
+
+    registrationHandlerService.removeValidators(registrationService1.getModelValidators(),
+            BaseResource.class);
+    verify(activateStatusService, times(2)).deactivateValidator(any(), any());
+  }
+
+  @Test
+  public void testRemoveValidatorsRemovesEmptyTypeKey() {
+    context.registerService(ModelValidatorRegistrationService.class, registrationService1);
+    context.registerService(ModelValidatorRegistrationService.class, registrationService2);
+    context.registerInjectActivateService(registrationHandlerService);
+    assertEquals(2, registrationHandlerService.getRegisteredModelValidatorMap().size());
+
+    registrationHandlerService.removeValidators(registrationService1.getModelValidators(),
+            BaseResource.class);
+    assertEquals(1, registrationHandlerService.getRegisteredModelValidatorMap().size());
+  }
+
+  @Test
+  public void testRemoveValidatorsWhenTypeNotRegistered() {
+    context.registerService(ModelValidatorRegistrationService.class, registrationService1);
+    context.registerInjectActivateService(registrationHandlerService);
+    // Should not throw when removing validators for a type that is not registered
+    registrationHandlerService.removeValidators(registrationService2.getModelValidators(),
+            BasePage.class);
+    assertEquals(1, registrationHandlerService.getRegisteredModelValidatorMap().size());
+  }
+
+  @Test
+  public void testRemoveValidatorsWithNullSafetyOnActivateStatusService() {
+    ModelValidatorRegistrationHandlerServiceImpl handlerWithoutActivateService
+            = new ModelValidatorRegistrationHandlerServiceImpl();
+    List<ModelValidator> validators = registrationService1.getModelValidators();
+    handlerWithoutActivateService.registeredModelValidatorMap.put(BaseResource.class,
+            new ArrayList<>(validators));
+    // Should not throw NullPointerException when activateStatusService is null
+    handlerWithoutActivateService.removeValidators(validators, BaseResource.class);
+    assertEquals(0,
+            handlerWithoutActivateService.registeredModelValidatorMap.get(BaseResource.class)
+                                         .size());
   }
 
   @Test


### PR DESCRIPTION
Implements removeValidators() which was a no-op with commented-out body. Now properly removes validators by message match, deactivates via activateStatusService, and cleans up empty map keys.