### PR TITLE
fix: null guard on optional validatorProviderService in validate()

### DIFF
--- a/src/main/java/io/kestros/commons/validation/core/services/impl/ModelValidationServiceImpl.java
+++ b/src/main/java/io/kestros/commons/validation/core/services/impl/ModelValidationServiceImpl.java
@@ -25,6 +25,7 @@ import io.kestros.commons.validation.api.models.ModelValidationResult;
 import io.kestros.commons.validation.api.services.ModelValidationService;
 import io.kestros.commons.validation.core.models.impl.ModelValidationResultImpl;
 import io.kestros.commons.validation.core.services.ModelValidatorProviderService;
+import java.util.Collections;
 import javax.annotation.Nonnull;
 import org.apache.felix.hc.api.FormattingResultLog;
 import org.osgi.service.component.ComponentContext;
@@ -80,6 +81,10 @@ public class ModelValidationServiceImpl implements ModelValidationService {
   @Nonnull
   @Override
   public <T extends BaseResource> ModelValidationResult validate(@Nonnull final T model) {
+    if (validatorProviderService == null) {
+      LOG.warn("ModelValidatorProviderService is not available. Returning empty validation result.");
+      return new ModelValidationResultImpl(model, Collections.emptyList());
+    }
     return new ModelValidationResultImpl(model,
             validatorProviderService.getActiveValidators(model.getClass()));
   }

--- a/src/test/java/io/kestros/commons/validation/core/services/impl/ModelValidationServiceImplTest.java
+++ b/src/test/java/io/kestros/commons/validation/core/services/impl/ModelValidationServiceImplTest.java
@@ -20,6 +20,8 @@
 package io.kestros.commons.validation.core.services.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -32,7 +34,6 @@ import org.apache.felix.hc.api.FormattingResultLog;
 import org.apache.felix.hc.api.Result;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -85,9 +86,10 @@ public class ModelValidationServiceImplTest {
   }
 
   @Test
-  @Ignore
   public void testValidateWhenValidatorProviderServiceIsNull() {
     context.registerInjectActivateService(modelValidationService);
-    modelValidationService.validate(resource);
+    ModelValidationResultImpl result = (ModelValidationResultImpl) modelValidationService.validate(resource);
+    assertNotNull(result);
+    assertTrue(result.getValidators().isEmpty());
   }
 }


### PR DESCRIPTION
## Summary
- Adds null check on `validatorProviderService` in `ModelValidationServiceImpl#validate()` to prevent NPE when the optional OSGi service is not bound
- Returns `ModelValidationResultImpl` with empty validator list when service is null, matching the pattern in `runAdditionalHealthChecks()`
- Enables previously `@Ignore`d test with proper assertions

## Red-green commit structure
1. **Red**: `test: enable test for null validatorProviderService` -- removes `@Ignore`, adds assertions, test fails with NPE
2. **Green**: `fix: add null guard on optional validatorProviderService in validate()` -- adds null check, test passes

## Test plan
- [x] `testValidateWhenValidatorProviderServiceIsNull` fails without fix (NPE)
- [x] `testValidateWhenValidatorProviderServiceIsNull` passes with fix
- [x] All existing tests pass (`mvn clean verify`)
- [x] No new warnings or errors introduced

Resolves TASK-303