### PR TITLE
fix: stop validation map duplicating bundle children on every render

### DIFF
--- a/src/main/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImpl.java
+++ b/src/main/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImpl.java
@@ -69,7 +69,12 @@ public class ValidatorResultImpl implements ValidatorResult {
       boolean hasInvalidValidator = false;
       this.bundled = new ArrayList<>();
       ModelValidatorBundle bundle = (ModelValidatorBundle) validator;
-      bundle.registerValidators();
+      // Only populate the bundle if it has not been registered yet. Bundle instances are cached and
+      // reused across every render; re-registering here appended the same child validators on each
+      // render, growing the validation map without bound (KDF validation panel showing duplicates).
+      if (bundle.getValidators().isEmpty()) {
+        bundle.registerValidators();
+      }
       for (Object childObject : bundle.getValidators()) {
         ModelValidator childValidator = (ModelValidator) childObject;
         ValidatorResult result = new ValidatorResultImpl(childValidator, model);

--- a/src/test/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImplTest.java
+++ b/src/test/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImplTest.java
@@ -107,6 +107,32 @@ public class ValidatorResultImplTest {
   }
 
   @Test
+  public void testGetBundledDoesNotAccumulateAcrossRendersOfSameBundle() {
+    // Bundle instances are cached and reused for every render. Rendering the same bundle more than
+    // once must not duplicate its child validators in the validation map.
+    List<ModelValidator> bundled = new ArrayList<>();
+    bundled.add(new SampleModelValidator(true, "Bundled Message 1", "",
+            ModelValidationMessageType.WARNING));
+    bundled.add(new SampleModelValidator(true, "Bundled Message 2", "",
+            ModelValidationMessageType.WARNING));
+
+    modelValidatorBundle = new SampleModelValidatorBundle(bundled, "Bundle root message", true);
+
+    ValidatorResultImpl firstRender = new ValidatorResultImpl(modelValidatorBundle, model);
+    assertEquals(2, firstRender.getBundled().size());
+
+    // Same bundle instance, second render — previously grew to 4 (then 6, 8, ...) on each render.
+    ValidatorResultImpl secondRender = new ValidatorResultImpl(modelValidatorBundle, model);
+    assertEquals(2, secondRender.getBundled().size());
+
+    ValidatorResultImpl thirdRender = new ValidatorResultImpl(modelValidatorBundle, model);
+    assertEquals(2, thirdRender.getBundled().size());
+
+    // The cached bundle's own child list must also stay flat.
+    assertEquals(2, modelValidatorBundle.getValidators().size());
+  }
+
+  @Test
   public void testGetValidatorClassPath() {
     modelValidator = new SampleModelValidator(true, "", "", ModelValidationMessageType.INFO);
     result = new ValidatorResultImpl(modelValidator, model);


### PR DESCRIPTION
## Problem
The KDF validation panel accumulated duplicate validation-map rows over time — e.g. a component's "Has a Sling Model", "Model Class has KestrosModel", etc. appeared 2×, then more on each subsequent render (one observed page had 108 `<li>` for what should be 4 items). Status (green/red) was unaffected; this is a cosmetic + slow-memory-leak defect on the cached bundle instances.

## Root cause
`ValidatorResultImpl` re-ran `bundle.registerValidators()` **unconditionally** every time it built a result for a `ModelValidatorBundle`:

```java
ModelValidatorBundle bundle = (ModelValidatorBundle) validator;
bundle.registerValidators();          // ran on every render
for (Object childObject : bundle.getValidators()) { ... }
```

Bundle instances are **cached** in the registration handler (`registeredModelValidatorMap`) and reused for every validation. `ModelValidatorBundle.addValidator()` is a plain `ArrayList.add()` with no clear/dedup, and the subclass `registerValidators()` overrides are unconditional. So each render appended the bundle's children again: `2 → 4 → 6 → …`, growing linearly with render count.

The base class's own `ModelValidatorBundle.isValidCheck()` already guards the identical call with `if (validators.isEmpty()) registerValidators();` — the renderer omitted that guard.

## Fix
Guard the registration the same way, so cached bundles are populated once and reused:

```java
if (bundle.getValidators().isEmpty()) {
  bundle.registerValidators();
}
```

One change in the shared renderer — fixes every bundle in every consumer (component-management, basic-components, forms-foundation, ui-management), no subclass changes.

## Test
Added `ValidatorResultImplTest.testGetBundledDoesNotAccumulateAcrossRendersOfSameBundle` — renders the same bundle instance three times and asserts the child count stays flat. Verified it **fails `expected:<2> but was:<4>` against the unfixed code** and passes with the fix. Full module suite: 47 tests, 0 failures, 1 (pre-existing) skip.

## Version
No version bump — `kestros-validation-core` is already on the unreleased `0.2.4-SNAPSHOT` (last release `0.2.3` untouched). Consumers resolve via `[0.2.1,0.2.99]` and pick this up on next snapshot deploy.