### PR TITLE
Keep every validation message, not just the last per severity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ under the License.
 
   <groupId>io.kestros.commons</groupId>
   <artifactId>kestros-validation-core</artifactId>
-  <version>0.2.4</version>
+  <version>0.2.5-SNAPSHOT</version>
 
   <packaging>bundle</packaging>
 

--- a/src/main/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImpl.java
+++ b/src/main/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImpl.java
@@ -27,6 +27,7 @@ import io.kestros.commons.validation.api.models.ModelValidationResult;
 import io.kestros.commons.validation.api.models.ModelValidator;
 import io.kestros.commons.validation.api.models.ValidatorResult;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +57,7 @@ public class ModelValidationResultImpl implements ModelValidationResult {
   public <T extends BaseResource> ModelValidationResultImpl(@Nonnull final T model,
           @Nonnull final List<ModelValidator> validators) {
     this.results = new ArrayList<>();
-    messagesMap = new HashMap<>();
+    messagesMap = new EnumMap<>(ModelValidationMessageType.class);
     this.model = model;
     this.validators = new ArrayList<>(validators);
     this.isValid = Boolean.TRUE;
@@ -66,7 +67,19 @@ public class ModelValidationResultImpl implements ModelValidationResult {
         this.isValid = Boolean.FALSE;
       }
       results.add(validatorResult);
-      messagesMap.putAll(validatorResult.getMessages());
+      // putAll REPLACES the list for a severity that is already present, so a second validator
+      // failing at the same severity used to discard the first one's messages. Merge per key, and
+      // copy the incoming list rather than storing the reference — getMessages() below hands the
+      // map out, and appending to a borrowed list would mutate the validator's own result.
+      for (Map.Entry<ModelValidationMessageType, List<String>> entry
+              : validatorResult.getMessages().entrySet()) {
+        List<String> existing = messagesMap.get(entry.getKey());
+        if (existing == null) {
+          existing = new ArrayList<>();
+          messagesMap.put(entry.getKey(), existing);
+        }
+        existing.addAll(entry.getValue());
+      }
     }
   }
 

--- a/src/main/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImpl.java
+++ b/src/main/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImpl.java
@@ -107,7 +107,6 @@ public class ModelValidationResultImpl implements ModelValidationResult {
     return isValid;
   }
 
-  @SuppressFBWarnings("UEC_USE_ENUM_COLLECTIONS")
   @Nonnull
   @Override
   public Map<ModelValidationMessageType, List<String>> getMessages() {

--- a/src/main/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImpl.java
+++ b/src/main/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImpl.java
@@ -57,7 +57,7 @@ public class ValidatorResultImpl implements ValidatorResult {
    * @param model Model to validate
    * @param <T> Model type.
    */
-  @SuppressFBWarnings({"PSC_PRESIZE_COLLECTIONS","UEC_USE_ENUM_COLLECTIONS"})
+  @SuppressFBWarnings("PSC_PRESIZE_COLLECTIONS")
   public <T extends BaseResource> ValidatorResultImpl(@Nonnull final ModelValidator validator,
           @Nonnull final T model) {
     this.messages = new EnumMap<>(ModelValidationMessageType.class);

--- a/src/main/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImpl.java
+++ b/src/main/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImpl.java
@@ -28,6 +28,7 @@ import io.kestros.commons.validation.api.models.ModelValidatorBundle;
 import io.kestros.commons.validation.api.models.ValidatorResult;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +60,7 @@ public class ValidatorResultImpl implements ValidatorResult {
   @SuppressFBWarnings({"PSC_PRESIZE_COLLECTIONS","UEC_USE_ENUM_COLLECTIONS"})
   public <T extends BaseResource> ValidatorResultImpl(@Nonnull final ModelValidator validator,
           @Nonnull final T model) {
-    this.messages = new HashMap<>();
+    this.messages = new EnumMap<>(ModelValidationMessageType.class);
     this.message = validator.getMessage();
     this.detailedMessage = validator.getDetailedMessage(model);
     this.validatorClassPath = validator.getClass().getName();
@@ -81,7 +82,17 @@ public class ValidatorResultImpl implements ValidatorResult {
         bundled.add(result);
         if (!result.isValid()) {
           hasInvalidValidator = true;
-          this.messages.putAll(result.getMessages());
+          // Same clobber as ModelValidationResultImpl: putAll drops the messages already held
+          // for that severity when a second bundled validator fails at the same one.
+          for (Map.Entry<ModelValidationMessageType, List<String>> entry
+                  : result.getMessages().entrySet()) {
+            List<String> existing = this.messages.get(entry.getKey());
+            if (existing == null) {
+              existing = new ArrayList<>();
+              this.messages.put(entry.getKey(), existing);
+            }
+            existing.addAll(entry.getValue());
+          }
         } else {
           hasValidValidator = true;
         }

--- a/src/test/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImplTest.java
+++ b/src/test/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImplTest.java
@@ -48,6 +48,52 @@ public class ModelValidationResultImplTest {
   }
 
   @Test
+  public void testGetMessagesKeepsEveryFailureAtTheSameSeverity() {
+    // Two validators failing at ERROR must both be reported. The map is keyed by severity, so the
+    // second one used to replace the first's list wholesale via putAll.
+    //
+    // Fails if: the merge at ModelValidationResultImpl is reverted to putAll — the ERROR list then
+    // holds only "Message 2" and the size assertion below reads 1.
+    final SampleModelValidator failing1 = new SampleModelValidator(false, "Message 1",
+            "Detailed Message 1", ModelValidationMessageType.ERROR);
+    final SampleModelValidator failing2 = new SampleModelValidator(false, "Message 2",
+            "Detailed Message 2", ModelValidationMessageType.ERROR);
+
+    validatorList.add(failing1);
+    validatorList.add(failing2);
+
+    result = new ModelValidationResultImpl(resource, validatorList);
+
+    final List<String> errors = result.getMessages().get(ModelValidationMessageType.ERROR);
+    assertEquals(2, errors.size());
+    assertTrue(errors.contains("Message 1"));
+    assertTrue(errors.contains("Message 2"));
+  }
+
+  @Test
+  public void testGetMessagesDoesNotMutateTheValidatorsOwnResult() {
+    // getMessages() hands the map out, so the merge must copy the incoming list rather than store
+    // the reference. Otherwise appending a second validator's messages would also append to the
+    // first validator's own result.
+    //
+    // Fails if: the merge stores entry.getValue() by reference instead of copying into a new
+    // ArrayList — the per-validator result then reports 2 errors instead of its own 1.
+    final SampleModelValidator failing1 = new SampleModelValidator(false, "Message 1",
+            "Detailed Message 1", ModelValidationMessageType.ERROR);
+    final SampleModelValidator failing2 = new SampleModelValidator(false, "Message 2",
+            "Detailed Message 2", ModelValidationMessageType.ERROR);
+
+    validatorList.add(failing1);
+    validatorList.add(failing2);
+
+    result = new ModelValidationResultImpl(resource, validatorList);
+    result.getMessages();
+
+    assertEquals(1,
+            result.getResults().get(0).getMessages().get(ModelValidationMessageType.ERROR).size());
+  }
+
+  @Test
   public void testGetResults() {
     SampleModelValidator validator1 = new SampleModelValidator(true, "Message 1",
             "Detailed Message 1", ModelValidationMessageType.ERROR);

--- a/src/test/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImplTest.java
+++ b/src/test/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImplTest.java
@@ -27,6 +27,7 @@ import io.kestros.commons.validation.api.ModelValidationMessageType;
 import io.kestros.commons.validation.api.models.ModelValidator;
 import io.kestros.commons.validation.core.models.impl.ModelValidationResultImpl;
 import io.kestros.commons.validation.core.samples.SampleModelValidator;
+import io.kestros.commons.validation.core.samples.SampleModelValidatorBundle;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.felix.hc.api.FormattingResultLog;
@@ -71,25 +72,31 @@ public class ModelValidationResultImplTest {
   }
 
   @Test
-  public void testGetMessagesDoesNotMutateTheValidatorsOwnResult() {
-    // getMessages() hands the map out, so the merge must copy the incoming list rather than store
-    // the reference. Otherwise appending a second validator's messages would also append to the
-    // first validator's own result.
+  public void testGetMessagesDoesNotGrowABundlesOwnMessageList() {
+    // The copy-in has to be tested where getting it wrong is SILENT. Two plain validators return
+    // Collections.singletonList, so a reference-storing merge throws UnsupportedOperation before
+    // any assertion runs — that proves the list is immutable, not that the copy works.
     //
-    // Fails if: the merge stores entry.getValue() by reference instead of copying into a new
-    // ArrayList — the per-validator result then reports 2 errors instead of its own 1.
-    final SampleModelValidator failing1 = new SampleModelValidator(false, "Message 1",
-            "Detailed Message 1", ModelValidationMessageType.ERROR);
-    final SampleModelValidator failing2 = new SampleModelValidator(false, "Message 2",
-            "Detailed Message 2", ModelValidationMessageType.ERROR);
+    // A bundle's messages are a mutable ArrayList handed out by reference, so a merge that
+    // retains the reference appends the standalone validator's message to the BUNDLE's own list.
+    //
+    // Fails if: the merge stores entry.getValue() instead of copying into a new ArrayList. The
+    // bundle then reports 3 errors of its own instead of 2, on the assertion below rather than by
+    // an exception thrown earlier.
+    final List<ModelValidator> bundled = new ArrayList<>();
+    bundled.add(new SampleModelValidator(false, "Bundled 1", "Detail 1",
+            ModelValidationMessageType.ERROR));
+    bundled.add(new SampleModelValidator(false, "Bundled 2", "Detail 2",
+            ModelValidationMessageType.ERROR));
 
-    validatorList.add(failing1);
-    validatorList.add(failing2);
+    validatorList.add(new SampleModelValidatorBundle(bundled, "Bundle root", true));
+    validatorList.add(new SampleModelValidator(false, "Standalone", "Detail 3",
+            ModelValidationMessageType.ERROR));
 
     result = new ModelValidationResultImpl(resource, validatorList);
-    result.getMessages();
 
-    assertEquals(1,
+    assertEquals(3, result.getMessages().get(ModelValidationMessageType.ERROR).size());
+    assertEquals(2,
             result.getResults().get(0).getMessages().get(ModelValidationMessageType.ERROR).size());
   }
 

--- a/src/test/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImplTest.java
+++ b/src/test/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImplTest.java
@@ -190,6 +190,29 @@ public class ValidatorResultImplTest {
   }
 
   @Test
+  public void testGetMessagesWhenBundledAndTwoChildrenFailAtTheSameSeverity() {
+    // The existing bundle test uses one ERROR child and one WARNING child, so it passes whether
+    // the messages are merged or overwritten. Two children at the SAME severity is the case the
+    // card's criterion 2 names and the only one that exercises the merge here.
+    //
+    // Fails if: the merge in ValidatorResultImpl is reverted to putAll. The ERROR list then holds
+    // only "Bundled Message 2" and the size assertion reads 1.
+    final List<ModelValidator> bundled = new ArrayList<>();
+    bundled.add(new SampleModelValidator(false, "Bundled Message 1", "",
+            ModelValidationMessageType.ERROR));
+    bundled.add(new SampleModelValidator(false, "Bundled Message 2", "",
+            ModelValidationMessageType.ERROR));
+
+    modelValidatorBundle = new SampleModelValidatorBundle(bundled, "Bundle root message", true);
+    result = new ValidatorResultImpl(modelValidatorBundle, model);
+
+    final List<String> errors = result.getMessages().get(ModelValidationMessageType.ERROR);
+    assertEquals(2, errors.size());
+    assertTrue(errors.contains("Bundled Message 1"));
+    assertTrue(errors.contains("Bundled Message 2"));
+  }
+
+  @Test
   public void testGetMessagesWhenBundledWhenBothFail() {
     List<ModelValidator> bundled = new ArrayList<>();
     ModelValidator bundledValidator1 = new SampleModelValidator(false, "Bundled Message 1", "",


### PR DESCRIPTION
Board card **172** — "BUG — a resource failing five validators reports one message" (http://localhost:8100/work_packages/172). Release 0.10.0, so this targets `temp-develop/cms-0.10.0`, not `develop`.

A resource failing more than one validator at the same severity reported only the last message. The messages map is keyed by severity and both accumulation sites used `Map.putAll`, which REPLACES the value for a key that is already present.

**Impact, from the card:** `kestros-filtering` sorts and filters resources on `getMessages().get(ERROR).size()` — `ResourceValidationSortMethod` and `ResourceValidationErrorFilterMethod`. Every failing resource reported exactly 1, so they all tied: the ordering was meaningless, not merely under-counted.

## What changed

- Merge per key at both sites — `ModelValidationResultImpl` (per-validator loop) and `ValidatorResultImpl` (bundled loop).
- **The incoming list is copied, not stored by reference.** `getMessages()` hands the map out, so a retained reference would grow the *bundle's own* list when a later validator's messages merged in.
- Both enum-keyed maps are now `EnumMap`, and the two `UEC_USE_ENUM_COLLECTIONS` suppressions that made dead are removed.
- Bumped `0.2.4` -> `0.2.5-SNAPSHOT`; develop sat on a released version.

`ValidatorResultImpl`'s `Collections.singletonList` write is deliberately untouched, per step 3 of the card. Copying on the way OUT is a separate card and is not attempted here.

## Verification

Three tests, each mutation-checked **by failure type** — every kill lands on an assertion, not an exception thrown earlier:

| Mutation | Test killed | Failure |
|---|---|---|
| revert `ModelValidationResultImpl` to `putAll` | `testGetMessagesKeepsEveryFailureAtTheSameSeverity` | assertion, `expected:<2> but was:<1>` |
| revert `ValidatorResultImpl` to `putAll` | `testGetMessagesWhenBundledAndTwoChildrenFailAtTheSameSeverity` | assertion, `expected:<2> but was:<1>` |
| store the list by reference | `testGetMessagesDoesNotGrowABundlesOwnMessageList` | assertion, `expected:<2> but was:<3>` |

All three also fail against untouched `develop` source, so fails-before / passes-after holds.

**Test counts.** The suite holds 50 test methods, one of which — `ModelValidatorRegistrationHandlerServiceImplTest.testUnregisterValidators` — is `@Ignore`d on `develop` already and is not this branch's doing. So **49 pass and 1 is skipped**. An earlier revision of this description and commit `0b66e9d` said "50/50 green"; that was wrong and is corrected here.

**Verification gate**, `Agent Verification / verify-branch` build #13 on this branch:

```
=== verification: kestros-validation-core @ fix/validation-messages-clobbered (module ., profiles strict) ===
build:  #13
url:    http://192.168.86.215:9001/job/Agent%20Verification/job/verify-branch/13/
result: SUCCESS
tests:  49 passed, 0 failed, 1 skipped
```

**Strict quality gates.** The Jenkins job passes `-Drat.skip -Dfindbugs.skip -Dcheckstyle.skip -Djacoco.haltOnFailure=false` unconditionally, so those checks do not run there whatever profile is requested. Run locally instead — `mvn clean verify -P strict`:

```
[INFO] You have 0 Checkstyle violations.
[INFO] Rat check: Summary over all files. Unapproved: 0, unknown: 0, generated: 0, approved: 19 licenses.
[INFO] Tests run: 50, Failures: 0, Errors: 0, Skipped: 1
[INFO] BugInstance size is 0
[INFO] Error size is 0
[INFO] No errors/warnings found
[INFO] All coverage checks have been met.
[INFO] BUILD SUCCESS
```

SpotBugs reports 0 with the `UEC_USE_ENUM_COLLECTIONS` suppressions removed, so those suppressions were in fact dead.
