### PR TITLE
Return copies of message lists from getMessages() (#171)

### DIFF
--- a/src/main/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImpl.java
+++ b/src/main/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImpl.java
@@ -58,6 +58,13 @@ public class ModelValidationResultImpl implements ModelValidationResult {
           @Nonnull final List<ModelValidator> validators) {
     this.results = new ArrayList<>();
     messagesMap = new EnumMap<>(ModelValidationMessageType.class);
+    // Seed every severity here rather than in getMessages(). Callers dereference the returned
+    // list directly — .size(), addAll, for-each, with no null check — so all three keys must be
+    // present whether or not they hold messages. Seeding on read made a getter write to its own
+    // field, and the seeded lists were then handed out by reference.
+    messagesMap.put(ModelValidationMessageType.ERROR, new ArrayList<>());
+    messagesMap.put(ModelValidationMessageType.WARNING, new ArrayList<>());
+    messagesMap.put(ModelValidationMessageType.INFO, new ArrayList<>());
     this.model = model;
     this.validators = new ArrayList<>(validators);
     this.isValid = Boolean.TRUE;
@@ -110,15 +117,14 @@ public class ModelValidationResultImpl implements ModelValidationResult {
   @Nonnull
   @Override
   public Map<ModelValidationMessageType, List<String>> getMessages() {
-    if (!messagesMap.containsKey(ModelValidationMessageType.ERROR)) {
-      messagesMap.put(ModelValidationMessageType.ERROR, new ArrayList<>());
+    // Copy the lists, not just the map. A new HashMap over the same lists still lets a caller
+    // append to the result's own messages. Copying rather than wrapping in an unmodifiable view
+    // keeps a mutating caller working: this is published to Maven Central, so the caller set is
+    // not closed by any survey, and a view would turn a silent no-op into a runtime throw.
+    final Map<ModelValidationMessageType, List<String>> copy = new HashMap<>(messagesMap);
+    for (Map.Entry<ModelValidationMessageType, List<String>> entry : copy.entrySet()) {
+      entry.setValue(new ArrayList<>(entry.getValue()));
     }
-    if (!messagesMap.containsKey(ModelValidationMessageType.WARNING)) {
-      messagesMap.put(ModelValidationMessageType.WARNING, new ArrayList<>());
-    }
-    if (!messagesMap.containsKey(ModelValidationMessageType.INFO)) {
-      messagesMap.put(ModelValidationMessageType.INFO, new ArrayList<>());
-    }
-    return new HashMap<>(messagesMap);
+    return copy;
   }
 }

--- a/src/main/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImpl.java
+++ b/src/main/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImpl.java
@@ -166,6 +166,14 @@ public class ValidatorResultImpl implements ValidatorResult {
   @Override
 
   public Map<ModelValidationMessageType, List<String>> getMessages() {
-    return new HashMap<>(messages);
+    // Copy every list, not just the map. A bundle's lists are mutable ArrayLists built in the
+    // constructor, so a new HashMap over them still lets a caller append to this result. Copying
+    // unconditionally also means the singletonList a plain validator holds is handed out as a
+    // mutable copy, so a mutating caller no longer gets an UnsupportedOperationException.
+    final Map<ModelValidationMessageType, List<String>> copy = new HashMap<>(messages);
+    for (Map.Entry<ModelValidationMessageType, List<String>> entry : copy.entrySet()) {
+      entry.setValue(new ArrayList<>(entry.getValue()));
+    }
+    return copy;
   }
 }

--- a/src/test/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImplTest.java
+++ b/src/test/java/io/kestros/commons/validation/core/models/impl/ModelValidationResultImplTest.java
@@ -101,6 +101,29 @@ public class ModelValidationResultImplTest {
   }
 
   @Test
+  public void testGetMessagesReturnsCopiesTheCallerCannotUseToEditTheResult() {
+    // getMessages() copies the map but not the lists inside it, so a caller that adds to a
+    // returned list is editing the result. Cover a populated severity and an empty one — the
+    // empty one is seeded by the getter on the base branch, so it aliases too.
+    //
+    // Fails if: getMessages() hands back the field's own lists. The second call then reports
+    // 2 errors instead of 1 and 1 warning instead of 0.
+    validatorList.add(new SampleModelValidator(false, "Message 1", "Detailed Message 1",
+            ModelValidationMessageType.ERROR));
+
+    result = new ModelValidationResultImpl(resource, validatorList);
+
+    result.getMessages().get(ModelValidationMessageType.ERROR).add("Injected error");
+    result.getMessages().get(ModelValidationMessageType.WARNING).add("Injected warning");
+
+    assertEquals(1, result.getMessages().get(ModelValidationMessageType.ERROR).size());
+    assertFalse(result.getMessages().get(ModelValidationMessageType.ERROR).contains(
+            "Injected error"));
+    assertEquals(0, result.getMessages().get(ModelValidationMessageType.WARNING).size());
+    assertEquals(3, result.getMessages().size());
+  }
+
+  @Test
   public void testGetResults() {
     SampleModelValidator validator1 = new SampleModelValidator(true, "Message 1",
             "Detailed Message 1", ModelValidationMessageType.ERROR);

--- a/src/test/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImplTest.java
+++ b/src/test/java/io/kestros/commons/validation/core/models/impl/ValidatorResultImplTest.java
@@ -213,6 +213,29 @@ public class ValidatorResultImplTest {
   }
 
   @Test
+  public void testGetMessagesReturnsCopiesTheCallerCannotUseToEditTheResult() {
+    // A bundle's message lists are mutable ArrayLists built in the constructor, and getMessages()
+    // copies the map but not the lists — so a caller that adds to a returned list edits the
+    // result. A plain validator stores a Collections.singletonList and would throw on add, which
+    // proves immutability rather than exercising the aliasing, so the bundle is the case to use.
+    //
+    // Fails if: getMessages() hands back the field's own list. The second call then reports 2
+    // errors instead of 1.
+    final List<ModelValidator> bundled = new ArrayList<>();
+    bundled.add(new SampleModelValidator(false, "Bundled Message 1", "",
+            ModelValidationMessageType.ERROR));
+
+    modelValidatorBundle = new SampleModelValidatorBundle(bundled, "Bundle root message", true);
+    result = new ValidatorResultImpl(modelValidatorBundle, model);
+
+    result.getMessages().get(ModelValidationMessageType.ERROR).add("Injected error");
+
+    assertEquals(1, result.getMessages().get(ModelValidationMessageType.ERROR).size());
+    assertFalse(result.getMessages().get(ModelValidationMessageType.ERROR).contains(
+            "Injected error"));
+  }
+
+  @Test
   public void testGetMessagesWhenBundledWhenBothFail() {
     List<ModelValidator> bundled = new ArrayList<>();
     ModelValidator bundledValidator1 = new SampleModelValidator(false, "Bundled Message 1", "",


### PR DESCRIPTION
Fixes #171.

`getMessages()` copied the messages map but not the lists inside it, so a caller that added to a returned list was editing the validation result. `ModelValidationResultImpl` also seeded missing severities while answering a read.

- Seeding of ERROR/WARNING/INFO moved into the `ModelValidationResultImpl` constructor. It had to move rather than disappear: 12 call sites across 5 repos dereference the returned list with no null check.
- Both `getMessages()` methods now build the returned map with a fresh `ArrayList` per severity.
- Copies rather than `Collections.unmodifiableList`: this module is published to Maven Central, so a view would turn a silent no-op into a runtime `UnsupportedOperationException` for callers no survey can reach.

New tests in `ModelValidationResultImplTest` and `ValidatorResultImplTest` mutate a returned list and assert the next call is unchanged. Both fail on `temp-develop/cms-0.10.0` at `ccec672` and pass after the change; both runs are quoted on the card. No existing test modified.

Opened with `--allow-unpublished`. `pom.xml:34` is `0.2.5-SNAPSHOT` on the base branch already and this PR does not change it — card #171 rules out a bump. The version being absent from Nexus is a property of the base, not of this change, and it needs the module built and deployed rather than re-versioned.